### PR TITLE
added deckofcards api integration

### DIFF
--- a/src/Components/DeckOfCardsService.ts
+++ b/src/Components/DeckOfCardsService.ts
@@ -1,0 +1,72 @@
+class DeckOfCardsService {
+    baseUrl: string;
+    deckId: null;
+
+    constructor() {
+      this.baseUrl = "https://deckofcardsapi.com/api/deck";
+      this.deckId = null;
+    }
+  
+    async createDeck(deckCount = 1) {
+      const response = await fetch(`${this.baseUrl}/new/shuffle/?deck_count=${deckCount}`);
+      const data = await response.json();
+      this.deckId = data.deck_id;
+      return data;
+    }
+  
+    async drawCards(count = 1) {
+      if (!this.deckId) await this.createDeck();
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/draw/?count=${count}`);
+      return response.json();
+    }
+  
+    async shuffleDeck(remaining = false) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const url = `${this.baseUrl}/${this.deckId}/shuffle/${remaining ? '?remaining=true' : ''}`;
+      const response = await fetch(url);
+      return response.json();
+    }
+  
+    async createPartialDeck(cards) {
+      const cardList = cards.join(',');
+      const response = await fetch(`${this.baseUrl}/new/shuffle/?cards=${cardList}`);
+      const data = await response.json();
+      this.deckId = data.deck_id;
+      return data;
+    }
+  
+    async addToPile(pileName, cards) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const cardList = cards.join(',');
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/pile/${pileName}/add/?cards=${cardList}`);
+      return response.json();
+    }
+  
+    async listPile(pileName) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/pile/${pileName}/list/`);
+      return response.json();
+    }
+  
+    async drawFromPile(pileName, count = 1) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/pile/${pileName}/draw/?count=${count}`);
+      return response.json();
+    }
+  
+    async shufflePile(pileName) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/pile/${pileName}/shuffle/`);
+      return response.json();
+    }
+  
+    async returnCards(cards) {
+      if (!this.deckId) throw new Error("No deck initialized.");
+      const cardList = cards.join(',');
+      const response = await fetch(`${this.baseUrl}/${this.deckId}/return/?cards=${cardList}`);
+      return response.json();
+    }
+  }
+  
+  export default DeckOfCardsService;
+  


### PR DESCRIPTION
createDeck(deckCount = 1)

- Calls the API to create a new shuffled deck with the specified number of decks.
- Stores the deck_id for future operations.
- Returns the response data.

drawCards(count = 1)

- Draws the specified number of cards from the deck.
- If no deck exists, it creates one first.
- Returns the response data containing drawn cards.

shuffleDeck(remaining = false)

- Shuffles the entire deck or only the remaining cards if remaining=true.
- Throws an error if no deck has been initialized.
- Returns the shuffle operation response.

createPartialDeck(cards)

- Creates a shuffled deck with only the specified cards.
- Stores the new deck_id.
- Returns the response data.

addToPile(pileName, cards)

- Adds specified cards to a named pile within the deck.
- Throws an error if no deck has been initialized.
- Returns the response confirming the action.

listPile(pileName)

- Retrieves details of a named pile (e.g., remaining cards).
- Throws an error if no deck has been initialized.
- Returns the response containing pile information.

drawFromPile(pileName, count = 1)

- Draws a specified number of cards from a pile.
- Throws an error if no deck has been initialized.
- Returns the drawn cards and updated pile details.

shufflePile(pileName)

- Shuffles a specific pile.
- Throws an error if no deck has been initialized.
- Returns the response confirming the shuffle.

returnCards(cards)

- Returns specified cards back to the deck for reuse.
- Throws an error if no deck has been initialized.
- Returns the response confirming the return.